### PR TITLE
Fix `ResponseNull` when pulling system information.

### DIFF
--- a/src/main/kotlin/dev/proxyfox/pluralkt/PluralKt.kt
+++ b/src/main/kotlin/dev/proxyfox/pluralkt/PluralKt.kt
@@ -43,6 +43,7 @@ object PluralKt {
         serializersModule = module
         prettyPrint = true
         isLenient = true
+        ignoreUnknownKeys = true
     }
     private val client = HttpClient(CIO) {
         install(UserAgent) {

--- a/src/main/kotlin/dev/proxyfox/pluralkt/types/PkSystem.kt
+++ b/src/main/kotlin/dev/proxyfox/pluralkt/types/PkSystem.kt
@@ -20,6 +20,8 @@ class PkSystem : PkType {
     var banner: String? = null
     var color: PkColor? = null
     var privacy: PkSystemPrivacy? = null
+    @SerialName("webhook_url")
+    var webhookUrl: String? = null
 
     override fun toString(): String = PluralKt.json.encodeToString(this)
 }


### PR DESCRIPTION
This PR fixes an unexpected `ResponseNull` response from the library caused by it finding an unknown key (`webhook_url`) in the JSON response.

This issue is fixed in 2 ways:

- Added `webhookUrl`/`webhook_url` parameter to the `PkSystem` class.
- Made the JSON serializer ignore unknown keys. 