### PR TITLE
Implement futures

### DIFF
--- a/src/main/kotlin/dev/proxyfox/pluralkt/Request.kt
+++ b/src/main/kotlin/dev/proxyfox/pluralkt/Request.kt
@@ -2,15 +2,32 @@ package dev.proxyfox.pluralkt
 
 import dev.proxyfox.pluralkt.types.*
 import io.ktor.util.reflect.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
 
-class Request<I, O>(val endpoint: String, val type: RequestType, val token: String?, val data: I?, val outputTypeInfo: TypeInfo, val inputTypeInfo: TypeInfo, val onComplete: Response<O>.() -> Unit) {
+class Request<I, O>(val endpoint: String, val type: RequestType, val token: String?, val data: I?, val outputTypeInfo: TypeInfo, val inputTypeInfo: TypeInfo) {
+    var onComplete: Response<O>.() -> Unit = {}
     fun createUrl(baseUrl: String) = baseUrl+endpoint
+
+    fun onComplete(action: Response<O>.() -> Unit) {
+        onComplete = action
+    }
+    fun future(): Future<Response<O>> {
+        val future = CompletableFuture<Response<O>>()
+        onComplete {
+            future.complete(this)
+        }
+        return future
+    }
+    fun await(): Response<O> {
+        return future().get()
+    }
 }
 
-inline fun <reified O> get(endpoint: String, token: String? = null, noinline onComplete: Response<O>.() -> Unit) = Request(endpoint, RequestType.GET, token, null, typeInfo<O>(), typeInfo<PkType>(), onComplete)
-inline fun <reified I, reified O> post(endpoint: String, data: I? = null, token: String, noinline onComplete: Response<O>.() -> Unit) = Request(endpoint, RequestType.POST, token, data, typeInfo<O>(), typeInfo<I>(), onComplete)
-inline fun <reified I, reified O> patch(endpoint: String, data: I? = null, token: String, noinline onComplete: Response<O>.() -> Unit) = Request(endpoint, RequestType.PATCH, token, data, typeInfo<O>(), typeInfo<I>(), onComplete)
-inline fun <reified O> delete(endpoint: String, token: String, noinline onComplete: Response<O>.() -> Unit) = Request(endpoint, RequestType.DELETE, token, null, typeInfo<O>(), typeInfo<PkType>(), onComplete)
+inline fun <reified O> get(endpoint: String, token: String? = null) = Request<PkType, O>(endpoint, RequestType.GET, token, null, typeInfo<O>(), typeInfo<PkType>())
+inline fun <reified I, reified O> post(endpoint: String, data: I? = null, token: String) = Request<I, O>(endpoint, RequestType.POST, token, data, typeInfo<O>(), typeInfo<I>())
+inline fun <reified I, reified O> patch(endpoint: String, data: I? = null, token: String) = Request<I, O>(endpoint, RequestType.PATCH, token, data, typeInfo<O>(), typeInfo<I>())
+inline fun <reified O> delete(endpoint: String, token: String) = Request<PkType, O>(endpoint, RequestType.DELETE, token, null, typeInfo<O>(), typeInfo<PkType>())
 
 enum class RequestType {
     GET,

--- a/src/main/kotlin/dev/proxyfox/pluralkt/Response.kt
+++ b/src/main/kotlin/dev/proxyfox/pluralkt/Response.kt
@@ -12,7 +12,7 @@ interface Response<T> {
 
     fun getError(): PkError
 
-    fun getException(): JsonConvertException
+    fun getException(): JsonConvertException?
 
     override fun toString(): String
 }
@@ -30,7 +30,7 @@ class ResponseSuccess<T>(private val value: T) : Response<T> {
     override fun toString(): String = value.toString()
 }
 
-class ResponseError<T>(private val error: PkError, private val exception: JsonConvertException) : Response<T> {
+class ResponseError<T>(private val error: PkError, private val exception: JsonConvertException? = null) : Response<T> {
     override fun isSuccess(): Boolean = false
 
     override fun getSuccess(): T = throw IllegalStateException("Response is not a success")
@@ -39,7 +39,7 @@ class ResponseError<T>(private val error: PkError, private val exception: JsonCo
 
     override fun getError(): PkError = error
 
-    override fun getException(): JsonConvertException = exception
+    override fun getException(): JsonConvertException? = exception
 
     override fun toString(): String = error.toString()
 }

--- a/src/test/kotlin/dev/proxyfox/pluralkt/test/TestMain.kt
+++ b/src/test/kotlin/dev/proxyfox/pluralkt/test/TestMain.kt
@@ -5,19 +5,13 @@ import dev.proxyfox.pluralkt.types.PkMessage
 import dev.proxyfox.pluralkt.types.PkSnowflake
 
 fun main() {
-    PluralKt.System.getSystem("aaaaa") {
+    PluralKt.System.getSystem("aaaaa").onComplete {
         println("GET: aaaaa")
         println("Success: "+this.isSuccess())
         println("Data: "+toString())
     }
-    PluralKt.System.getSystem("exmpl") {
-        println("GET: exmpl")
-        println("Success: "+this.isSuccess())
-        println("Data: "+toString())
-    }
-    PluralKt.Misc.getMessage(PkSnowflake(1068939961946083348UL)) {
-        println("GET: 1068939961946083348UL")
-        println("Success: "+this.isSuccess())
-        println("Data: "+toString())
-    }
+    val system = PluralKt.System.getSystem("exmpl").await()
+    println("GET: exmpl")
+    println("Success: "+system.isSuccess())
+    println("Data: $system")
 }


### PR DESCRIPTION
In a PR since this is a breaking change

Example usage:
```kt
PluralKt.System.getSystem("aaaaa").onComplete {
    println("GET: aaaaa")
    println("Success: "+this.isSuccess())
    println("Data: "+toString())
}
// Can use .await() instead of .future().get()
val system = PluralKt.System.getSystem("exmpl").future().get()
println("GET: exmpl")
println("Success: "+system.isSuccess())
println("Data: $system")
```

Old behaviour:
```kt
PluralKt.System.getSystem("aaaaa") {
    println("GET: aaaaa")
    println("Success: "+this.isSuccess())
    println("Data: "+toString())
}
```